### PR TITLE
Add Mac Admins Open Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -2097,3 +2097,7 @@ https://www.openprivacytech.org
 ### Poetry
 Python packaging and dependency management made easy 
 https://python-poetry.org 
+
+### Mac Admins Open Source
+We are an organization to empower open source projects in the Mac Admin community.
+www.macadmins.io

--- a/README.md
+++ b/README.md
@@ -2097,3 +2097,7 @@ https://www.openprivacytech.org
 ### Poetry
 Python packaging and dependency management made easy 
 https://python-poetry.org 
+
+### project-based-learning-master
+A list of programming tutorials in which aspiring software developers learn how to build an application from scratch. These tutorials are divided into different primary programming languages. Tutorials may involve multiple technologies and languages.
+https://github.com/hungvmlotus/project-based-learning-master


### PR DESCRIPTION
as titled

## Your Project ##

#### 1Password Teams URL ####
https://macadminsopensource.1password.com

#### Project Name ####
Mac Admins Open Source

#### Short Description ####
This organization exists to empower open source within the Mac Admins community. Projects that we support are used across many Universities and Corporations of all sizes.

#### Project Age ####
8+ years on Github, longer before Github

#### Number Of Core Contributors ####
~9 Owners

#### Project Website ####
https://www.macadmins.io
(DNS might not be propagated yet, should redirect to our GitHub)

#### Repository URL(s) ####
https://github.com/macadmins

#### Latest Release URL(s) ####
Various projects. Latest 2:
Nudge - https://github.com/macadmins/nudge/releases
ossuary-extension - https://github.com/macadmins/osquery-extension/releases


#### License Type ####
MIT, generally. 

#### License URL ####
https://github.com/macadmins/nudge/blob/main/LICENSE

## A Bit About Yourself  ##
I've been involved in the Mac Admin open source community since 2011 and have worked on the Client management teams at various companies.

#### Name ####
Nate Walck

#### Email ####
nate@macadmins.io

#### Project Role ####
Owner

#### Profile/Website ####
https://www.linkedin.com/in/natewalck

#### Comments ####
Ya'll rock! Been a 1Password use since 1.0 :D 